### PR TITLE
Added 'add_income' command

### DIFF
--- a/src/main/java/thrift/logic/parser/AddExpenseCommandParser.java
+++ b/src/main/java/thrift/logic/parser/AddExpenseCommandParser.java
@@ -33,7 +33,7 @@ public class AddExpenseCommandParser extends AddTransactionCommandParser impleme
 
         Description description = parseTransactionDescription(argMultimap);
         Value value = parseTransactionValue(argMultimap);
-        TransactionDate date = parseTransactionDate(argMultimap);
+        TransactionDate date = parseTransactionDate();
         Set<Tag> tagList = parseTransactionTags(argMultimap);
 
         Expense expense = new Expense(description, value, date, tagList);

--- a/src/main/java/thrift/logic/parser/AddIncomeCommandParser.java
+++ b/src/main/java/thrift/logic/parser/AddIncomeCommandParser.java
@@ -33,7 +33,7 @@ public class AddIncomeCommandParser extends AddTransactionCommandParser implemen
 
         Description description = parseTransactionDescription(argMultimap);
         Value value = parseTransactionValue(argMultimap);
-        TransactionDate date = parseTransactionDate(argMultimap);
+        TransactionDate date = parseTransactionDate();
         Set<Tag> tagList = parseTransactionTags(argMultimap);
 
         Income income = new Income(description, value, date, tagList);

--- a/src/main/java/thrift/logic/parser/AddIncomeCommandParser.java
+++ b/src/main/java/thrift/logic/parser/AddIncomeCommandParser.java
@@ -3,32 +3,32 @@ package thrift.logic.parser;
 import java.util.Set;
 
 import thrift.commons.core.Messages;
-import thrift.logic.commands.AddExpenseCommand;
+import thrift.logic.commands.AddIncomeCommand;
 import thrift.logic.parser.exceptions.ParseException;
 import thrift.model.tag.Tag;
 import thrift.model.transaction.Description;
-import thrift.model.transaction.Expense;
+import thrift.model.transaction.Income;
 import thrift.model.transaction.TransactionDate;
 import thrift.model.transaction.Value;
 
 /**
- * Parses input arguments and creates a new AddExpenseCommand object.
+ * Parses input arguments and creates a new AddIncomeCommand object.
  */
-public class AddExpenseCommandParser extends AddTransactionCommandParser implements Parser<AddExpenseCommand> {
+public class AddIncomeCommandParser extends AddTransactionCommandParser implements Parser<AddIncomeCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the AddExpenseCommand
-     * and returns an AddExpenseCommand object for execution.
-     * @throws ParseException if the user input does not conform to the expected format
+     * Parses the given {@code String} of arguments in the context of the AddIncomeCommand
+     * and returns an AddIncomeCommand object for execution.
+     * @throws ParseException if the user input does not conform to the expected format.
      */
-    public AddExpenseCommand parse(String args) throws ParseException {
+    public AddIncomeCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_COST, CliSyntax.PREFIX_TAG);
 
         if (!arePrefixesPresent(argMultimap, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_COST)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
-                    AddExpenseCommand.MESSAGE_USAGE));
+                    AddIncomeCommand.MESSAGE_USAGE));
         }
 
         Description description = parseTransactionDescription(argMultimap);
@@ -36,8 +36,8 @@ public class AddExpenseCommandParser extends AddTransactionCommandParser impleme
         TransactionDate date = parseTransactionDate(argMultimap);
         Set<Tag> tagList = parseTransactionTags(argMultimap);
 
-        Expense expense = new Expense(description, value, date, tagList);
+        Income income = new Income(description, value, date, tagList);
 
-        return new AddExpenseCommand(expense);
+        return new AddIncomeCommand(income);
     }
 }

--- a/src/main/java/thrift/logic/parser/AddTransactionCommandParser.java
+++ b/src/main/java/thrift/logic/parser/AddTransactionCommandParser.java
@@ -18,25 +18,47 @@ import thrift.model.transaction.Value;
 public abstract class AddTransactionCommandParser {
 
     /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
+     * This methods checks if the required prefixes are present in the {@code ArgumentMultimap}.
+     *
+     * @param argumentMultimap the object to check for the existence of prefixes.
+     * @param prefixes variable amount of {@code Prefix} to confirm the existence of.
+     * @return true if specified prefixes are present in the argumentMultimap.
      */
     protected static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
+    /**
+     * Parses for {@code Description} object given the {@code ArgumentMultimap} object.
+     * @param argMultimap the object to parse from.
+     * @return {@code Description} object based on the values in the input {@code ArgumentMultimap}.
+     */
     protected Description parseTransactionDescription(ArgumentMultimap argMultimap) {
         return ParserUtil.parseDescription(argMultimap.getValue(CliSyntax.PREFIX_NAME).get());
     }
 
+    /**
+     * Parses for {@code Value} object given the {@code ArgumentMultimap} object.
+     * @param argMultimap the object to parse from.
+     * @return {@code Value} object based on the values in the input {@code ArgumentMultimap}.
+     */
     protected Value parseTransactionValue(ArgumentMultimap argMultimap) throws ParseException {
         return ParserUtil.parseValue(argMultimap.getValue(CliSyntax.PREFIX_COST).get());
     }
 
-    protected TransactionDate parseTransactionDate(ArgumentMultimap argMultimap) {
+    /**
+     * Parses for {@code TransactionDate} object using the current System's date.
+     * @return {@code TransactionDate} object based on the current System's date.
+     */
+    protected TransactionDate parseTransactionDate() {
         return new TransactionDate(DATE_FORMATTER.format(new Date()));
     }
 
+    /**
+     * Parses for {@code Set<Tag>} object given the {@code ArgumentMultimap} object.
+     * @param argMultimap the object to parse from.
+     * @return {@code Set<Tag>} object based on the values in the input {@code ArgumentMultimap}.
+     */
     protected Set<Tag> parseTransactionTags(ArgumentMultimap argMultimap) throws ParseException {
         return ParserUtil.parseTags(argMultimap.getAllValues(CliSyntax.PREFIX_TAG));
     }

--- a/src/main/java/thrift/logic/parser/AddTransactionCommandParser.java
+++ b/src/main/java/thrift/logic/parser/AddTransactionCommandParser.java
@@ -1,0 +1,44 @@
+package thrift.logic.parser;
+
+import static thrift.model.transaction.TransactionDate.DATE_FORMATTER;
+
+import java.util.Date;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import thrift.logic.parser.exceptions.ParseException;
+import thrift.model.tag.Tag;
+import thrift.model.transaction.Description;
+import thrift.model.transaction.TransactionDate;
+import thrift.model.transaction.Value;
+
+/**
+ * Parses common parameters that are necessary for either AddExpenseCommand or AddIncomeCommand.
+ */
+public abstract class AddTransactionCommandParser {
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    protected static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    protected Description parseTransactionDescription(ArgumentMultimap argMultimap) {
+        return ParserUtil.parseDescription(argMultimap.getValue(CliSyntax.PREFIX_NAME).get());
+    }
+
+    protected Value parseTransactionValue(ArgumentMultimap argMultimap) throws ParseException {
+        return ParserUtil.parseValue(argMultimap.getValue(CliSyntax.PREFIX_COST).get());
+    }
+
+    protected TransactionDate parseTransactionDate(ArgumentMultimap argMultimap) {
+        return new TransactionDate(DATE_FORMATTER.format(new Date()));
+    }
+
+    protected Set<Tag> parseTransactionTags(ArgumentMultimap argMultimap) throws ParseException {
+        return ParserUtil.parseTags(argMultimap.getAllValues(CliSyntax.PREFIX_TAG));
+    }
+
+}

--- a/src/main/java/thrift/logic/parser/ThriftParser.java
+++ b/src/main/java/thrift/logic/parser/ThriftParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import thrift.logic.commands.AddExpenseCommand;
+import thrift.logic.commands.AddIncomeCommand;
 import thrift.logic.commands.ClearCommand;
 import thrift.logic.commands.Command;
 import thrift.logic.commands.DeleteCommand;
@@ -47,6 +48,9 @@ public class ThriftParser {
 
         case AddExpenseCommand.COMMAND_WORD:
             return new AddExpenseCommandParser().parse(arguments);
+
+        case AddIncomeCommand.COMMAND_WORD:
+            return new AddIncomeCommandParser().parse(arguments);
 
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);

--- a/src/main/java/thrift/model/transaction/Value.java
+++ b/src/main/java/thrift/model/transaction/Value.java
@@ -21,7 +21,7 @@ public class Value {
             "Currency should only be 'SGD', 'MYR', 'USD' OR 'EUR'!";
     public static final String VALIDATION_REGEX = "^\\d+\\.?\\d{0,2}$";
     public static final String DEFAULT_CURRENCY = "SGD";
-    private static final DecimalFormat decimalFormatter = new DecimalFormat("0.00");
+    private static final DecimalFormat decimalFormatter = new DecimalFormat("#,##0.00");
 
     public final Double amount;
     public final String currency;
@@ -83,6 +83,14 @@ public class Value {
     public double getMonetaryValue() {
         Map<String, Double> currencyMappings = CurrencyUtil.getCurrencyMap();
         return CurrencyUtil.convertFromDefaultCurrency(currencyMappings, amount, currency);
+    }
+
+    /**
+     * Returns the value from {@link #getMonetaryValue()} in String type. This is useful for formatting to JSON and
+     * storing.
+     */
+    public String getUnformattedString() {
+        return Double.toString(getMonetaryValue());
     }
 
     @Override

--- a/src/main/java/thrift/storage/JsonAdaptedTransaction.java
+++ b/src/main/java/thrift/storage/JsonAdaptedTransaction.java
@@ -57,7 +57,7 @@ class JsonAdaptedTransaction {
             type = "income";
         }
         description = source.getDescription().toString();
-        value = source.getValue().toString();
+        value = source.getValue().getUnformattedString();
         date = source.getDate().toString();
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)

--- a/src/test/java/thrift/logic/commands/AddExpenseCommandIntegrationTest.java
+++ b/src/test/java/thrift/logic/commands/AddExpenseCommandIntegrationTest.java
@@ -13,10 +13,8 @@ import thrift.model.ModelManager;
 import thrift.model.PastUndoableCommands;
 import thrift.model.UserPrefs;
 import thrift.model.transaction.Expense;
-import thrift.model.transaction.Income;
 import thrift.model.transaction.Transaction;
 import thrift.testutil.ExpenseBuilder;
-import thrift.testutil.IncomeBuilder;
 import thrift.testutil.TypicalTransactions;
 
 /**
@@ -40,17 +38,6 @@ public class AddExpenseCommandIntegrationTest {
 
         assertCommandSuccess(new AddExpenseCommand(validExpense), model,
                 String.format(AddExpenseCommand.MESSAGE_SUCCESS, validExpense), expectedModel);
-    }
-
-    @Test
-    public void execute_newIncome_success() {
-        Income validIncome = new IncomeBuilder().build();
-
-        Model expectedModel = new ModelManager(model.getThrift(), new UserPrefs(), new PastUndoableCommands());
-        expectedModel.addIncome(validIncome);
-
-        assertCommandSuccess(new AddIncomeCommand(validIncome), model,
-                String.format(AddIncomeCommand.MESSAGE_SUCCESS, validIncome), expectedModel);
     }
 
     @Test

--- a/src/test/java/thrift/logic/commands/AddIncomeCommandIntegrationTest.java
+++ b/src/test/java/thrift/logic/commands/AddIncomeCommandIntegrationTest.java
@@ -1,0 +1,38 @@
+package thrift.logic.commands;
+
+import static thrift.logic.commands.CommandTestUtil.assertCommandSuccess;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import thrift.model.Model;
+import thrift.model.ModelManager;
+import thrift.model.PastUndoableCommands;
+import thrift.model.UserPrefs;
+import thrift.model.transaction.Income;
+import thrift.testutil.IncomeBuilder;
+import thrift.testutil.TypicalTransactions;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code AddIncomeCommand}
+ */
+public class AddIncomeCommandIntegrationTest {
+
+    private Model model;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(TypicalTransactions.getTypicalThrift(), new UserPrefs(), new PastUndoableCommands());
+    }
+
+    @Test
+    public void execute_newIncome_success() {
+        Income validIncome = new IncomeBuilder().build();
+
+        Model expectedModel = new ModelManager(model.getThrift(), new UserPrefs(), new PastUndoableCommands());
+        expectedModel.addIncome(validIncome);
+
+        assertCommandSuccess(new AddIncomeCommand(validIncome), model,
+                String.format(AddIncomeCommand.MESSAGE_SUCCESS, validIncome), expectedModel);
+    }
+}

--- a/src/test/java/thrift/logic/commands/CommandTestUtil.java
+++ b/src/test/java/thrift/logic/commands/CommandTestUtil.java
@@ -24,21 +24,28 @@ import thrift.testutil.EditTransactionDescriptorBuilder;
  */
 public class CommandTestUtil {
 
+    public static final String VALID_DESCRIPTION_BURSARY = "Bursary";
     public static final String VALID_DESCRIPTION_LAKSA = "Laksa";
     public static final String VALID_DESCRIPTION_PENANG_LAKSA = "Penang Laksa";
     public static final String VALID_DESCRIPTION_AIRPODS = "Airpods";
+    public static final String VALID_VALUE_BURSARY = "500";
     public static final String VALID_VALUE_LAKSA = "3.50";
     public static final String VALID_VALUE_AIRPODS = "350";
+    public static final String VALID_DATE_BURSARY = "09/10/2019";
     public static final String VALID_DATE_LAKSA = "13/03/1937";
     public static final String VALID_DATE_AIRPODS = "14/03/1937";
+    public static final String VALID_TAG_AWARD = "Award";
     public static final String VALID_TAG_LUNCH = "Lunch";
     public static final String VALID_TAG_BRUNCH = "Brunch";
     public static final String VALID_TAG_ACCESSORY = "Accessory";
 
+    public static final String DESC_BURSARY = " " + PREFIX_NAME + VALID_DESCRIPTION_BURSARY;
     public static final String DESC_LAKSA = " " + PREFIX_NAME + VALID_DESCRIPTION_LAKSA;
     public static final String DESC_AIRPODS = " " + PREFIX_NAME + VALID_DESCRIPTION_AIRPODS;
+    public static final String VALUE_BURSARY = " " + PREFIX_COST + VALID_VALUE_BURSARY;
     public static final String VALUE_LAKSA = " " + PREFIX_COST + VALID_VALUE_LAKSA;
     public static final String VALUE_AIRPODS = " " + PREFIX_COST + VALID_VALUE_AIRPODS;
+    public static final String TAG_BURSARY = " " + PREFIX_TAG + VALID_TAG_AWARD;
     public static final String TAG_LAKSA = " " + PREFIX_TAG + VALID_TAG_LUNCH;
     public static final String TAG_BRUNCH = " " + PREFIX_TAG + VALID_TAG_BRUNCH;
     public static final String TAG_AIRPODS = " " + PREFIX_TAG + VALID_TAG_ACCESSORY;

--- a/src/test/java/thrift/logic/parser/AddExpenseCommandParserTest.java
+++ b/src/test/java/thrift/logic/parser/AddExpenseCommandParserTest.java
@@ -50,8 +50,6 @@ public class AddExpenseCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
-
-
         // invalid value
         CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.DESC_LAKSA
                 + CommandTestUtil.INVALID_VALUE + CommandTestUtil.TAG_LAKSA

--- a/src/test/java/thrift/logic/parser/AddIncomeCommandParserTest.java
+++ b/src/test/java/thrift/logic/parser/AddIncomeCommandParserTest.java
@@ -1,0 +1,73 @@
+package thrift.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static thrift.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import org.junit.jupiter.api.Test;
+
+import thrift.logic.commands.AddIncomeCommand;
+import thrift.logic.commands.CommandTestUtil;
+import thrift.model.tag.Tag;
+import thrift.model.transaction.Value;
+
+
+public class AddIncomeCommandParserTest {
+    private AddIncomeCommandParser parser = new AddIncomeCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        // whitespace only preamble
+        assertDoesNotThrow(() -> parser.parse(CommandTestUtil.PREAMBLE_WHITESPACE
+                + CommandTestUtil.DESC_BURSARY + CommandTestUtil.VALUE_BURSARY
+                + CommandTestUtil.TAG_BURSARY));
+
+        // multiple tags - all accepted
+        assertDoesNotThrow(() -> parser.parse(CommandTestUtil.DESC_BURSARY + CommandTestUtil.VALUE_BURSARY
+                + CommandTestUtil.TAG_BURSARY + CommandTestUtil.TAG_AIRPODS));
+    }
+
+    @Test
+    public void parse_optionalFieldsMissing_success() {
+        // zero tags
+        assertDoesNotThrow(() -> parser.parse(CommandTestUtil.DESC_BURSARY + CommandTestUtil.VALUE_BURSARY));
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        // zero tags
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddIncomeCommand.MESSAGE_USAGE);
+
+        // missing description prefix
+        CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.VALID_DESCRIPTION_BURSARY
+                + CommandTestUtil.VALUE_BURSARY, expectedMessage);
+
+        // missing value prefix
+        CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.DESC_BURSARY
+                + CommandTestUtil.VALID_VALUE_BURSARY, expectedMessage);
+
+        // all prefixes missing
+        CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.VALID_DESCRIPTION_BURSARY
+                + CommandTestUtil.VALID_VALUE_BURSARY, expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid value
+        CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.DESC_BURSARY
+                + CommandTestUtil.INVALID_VALUE + CommandTestUtil.TAG_BURSARY, Value.VALUE_CONSTRAINTS);
+
+        // invalid tag
+        CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.DESC_BURSARY
+                + CommandTestUtil.VALUE_BURSARY + CommandTestUtil.INVALID_TAG, Tag.MESSAGE_CONSTRAINTS);
+
+        // two invalid values, only first invalid value reported
+        CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.DESC_BURSARY
+                + CommandTestUtil.INVALID_VALUE + CommandTestUtil.INVALID_TAG, Value.VALUE_CONSTRAINTS);
+
+        // non-empty preamble
+        CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.PREAMBLE_NON_EMPTY
+                + CommandTestUtil.DESC_BURSARY + CommandTestUtil.VALUE_BURSARY + CommandTestUtil.TAG_BURSARY,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddIncomeCommand.MESSAGE_USAGE));
+    }
+
+}


### PR DESCRIPTION
Other changes:
1. Improved the way large money values are shown: "1000000.00" - "1,000,000.00".
2. The raw transaction values ("1000000.00" instead of "1,000,000.00") are now stored into the `JSON` data file instead of the formatted one, to ease restoration of `Transaction` objects upon application startup.

<br><br>
===Ignore the following tags===
Resolves #3 Resolves #4 Resolves #8 Resolves #9 Resolves #10 Resolves #12 Resolves #16 Resolves #25 Resolves #27 Resolves #29 Resolves #32 Resolves #37 Resolves #50 