### PR TITLE
Added Remark field into Transactions using the prefix 'r/'

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -48,35 +48,35 @@ Command format:
 [[ExpenseTag]]
 === Adding an expense: `add_expense`
 
-Format: `add_expense n/EXPENSE_NAME c/COST [t/TAG]...`
+Format: `add_expense n/EXPENSE_NAME c/COST [r/REMARKS] [t/TAG]...`
 
 TIP: The default currency is in Singapore Dollars (SGD). You are recommended to `convert` foreign currencies to SGD before adding the value as the `COST`.
 
 Examples:
 
 *   `add_expense n/Laksa c/10.50 t/Lunch t/Food`
-*   `add_expense n/Travel c/53 t/Travel`
+*   `add_expense n/Travel c/53 r/Went to Johor Bahru t/Travel`
 
 Expected output:
 
-*   `New entry added: 1. [-] Laksa ($10.50) [Lunch][Food]`
-*   `New entry added: 2. [-] Travel ($53) [Travel]`
+*   `New expense added: [-] Laksa ($10.50) Date: 12/10/2019 Remarks:  Tags: [Lunch][Food]`
+*   `New expense added: [-] Travel ($53.00) Date: 12/10/2019 Remarks: Went to Johor Bahru Tags: [Travel]`
 
 
 [[IncomeTag]]
 === Adding an income: `add_income`
 
-Format: `add_income n/INCOME_NAME c/COST [t/TAG]...`
+Format: `add_income n/INCOME_NAME c/COST [r/REMARKS] [t/TAG]...`
 
 Examples:
 
 *   `add_income n/Allowance c/1000 t/Monthly`
+*   `add_income n/Bursary c/500 r/Did well in previous semester. t/Award`
 
 Expected output:
 
-*   `New entry added: 3. [+] Allowance ($1000) [Monthly]`
-
-
+*   `New income added: [+] Allowance ($1,000.00) Date: 12/10/2019 Remarks:  Tags: [Monthly]`
+*   `New income added: [+] Bursary ($500.00) Date: 12/10/2019 Remarks: Did well in previous semester. Tags: [Award]`
 
 [[DeleteTag]]
 === Deleting a transaction: `delete`
@@ -95,7 +95,7 @@ Examples:
 
 Expected output:
 
-*   `Entry deleted: 1. Laksa ($10.50) [Lunch][Food]`
+*   `Deleted Transaction: [-] Laksa ($10.50) Date: 12/10/2019 Remarks:  Tags: [Lunch][Food]`
 
 // tag::update[]
 [[UpdateTag]]
@@ -114,14 +114,14 @@ Format: `update i/INDEX PREFIX_LETTER/UPDATED_DETAILS ...`
 Examples:
 
 *   `update i/1 n/Curry Laksa`
-*   `update i/1 n/Asam Laksa c/11 t/Dinner t/Food`
+*   `update i/1 n/Asam Laksa c/11 r/My first time trying! t/Dinner t/Food`
 
 Expected output: +
 
 NOTE: Assume 2nd command occurs after 1st
 
-*   `Updated Transaction: [-] Curry Laksa ($10.50) Date: 09/10/2019 Tags: [Food][Lunch]` +
-*   `Updated Transaction: [-] Asam Laksa ($11.00) Date: 09/10/2019 Tags: [Dinner][Food]`
+*   `Updated Transaction: [-] Curry Laksa ($10.50) Date: 12/10/2019 Remarks:  Tags: [Lunch][Food]` +
+*   `Updated Transaction: [-] Asam Laksa ($11.00) Date: 12/10/2019 Remarks: My first time trying! Tags: [Dinner][Food]`
 // end::update[]
 
 //tag::tag[]
@@ -323,10 +323,10 @@ If you are especially conscious about having your data spied on, this function w
 *A*: Runs the application in the other computer and overwrite the empty data file it creates with the file that contains the data of your previous THRIFT application.
 
 == Command summary
-* <<ExpenseTag, *Expense*>>:  `add_expense n/EXPENSE_NAME c/COST [t/TAG]...` +
-Example: `add_expense n/Laksa c/10.50 t/Lunch t/Food`
+* <<ExpenseTag, *Expense*>>:  `add_expense n/EXPENSE_NAME c/COST [r/REMARKS] [t/TAG]...` +
+Example: `add_expense n/Laksa c/10.50 r/At Hougang t/Lunch t/Food`
 * <<IncomeTag, *Income*>>: `add_income n/INCOME_NAME c/COST [t/TAG]...` +
-Example: `add_income n/Allowance c/1000 t/Monthly`
+Example: `add_income n/Allowance c/1000 r/From my parents t/Monthly`
 * <<DeleteTag, *Delete*>>: `delete i/INDEX` +
 Example: `delete i/1`
 * <<UpdateTag, *Update*>>: `update i/INDEX PREFIX_LETTER/UPDATED_DETAILS ...` +

--- a/src/main/java/thrift/logic/commands/AddExpenseCommand.java
+++ b/src/main/java/thrift/logic/commands/AddExpenseCommand.java
@@ -20,10 +20,12 @@ public class AddExpenseCommand extends Command implements Undoable {
             + "Parameters: "
             + CliSyntax.PREFIX_NAME + "NAME DESCRIPTION "
             + CliSyntax.PREFIX_COST + "COST "
+            + "[" + CliSyntax.PREFIX_REMARK + "REMARK] "
             + "[" + CliSyntax.PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + CliSyntax.PREFIX_NAME + "Laksa "
             + CliSyntax.PREFIX_COST + "4.50 "
+            + CliSyntax.PREFIX_REMARK + "Ate at Changi Village "
             + CliSyntax.PREFIX_TAG + "Lunch "
             + CliSyntax.PREFIX_TAG + "Meal ";
 

--- a/src/main/java/thrift/logic/commands/AddIncomeCommand.java
+++ b/src/main/java/thrift/logic/commands/AddIncomeCommand.java
@@ -17,12 +17,13 @@ public class AddIncomeCommand extends Command {
             + "Parameters: "
             + CliSyntax.PREFIX_NAME + "NAME DESCRIPTION "
             + CliSyntax.PREFIX_COST + "COST "
+            + "[" + CliSyntax.PREFIX_REMARK + "REMARK] "
             + "[" + CliSyntax.PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
-            + CliSyntax.PREFIX_NAME + "Laksa "
-            + CliSyntax.PREFIX_COST + "4.50 "
-            + CliSyntax.PREFIX_TAG + "Lunch "
-            + CliSyntax.PREFIX_TAG + "Meal ";
+            + CliSyntax.PREFIX_NAME + "Bursary "
+            + CliSyntax.PREFIX_COST + "500 "
+            + CliSyntax.PREFIX_REMARK + "For studying well "
+            + CliSyntax.PREFIX_TAG + "Award ";
 
     public static final String MESSAGE_SUCCESS = "New income added: %1$s";
 

--- a/src/main/java/thrift/logic/commands/UpdateCommand.java
+++ b/src/main/java/thrift/logic/commands/UpdateCommand.java
@@ -36,6 +36,7 @@ public class UpdateCommand extends Command {
             + "Parameters: " + CliSyntax.PREFIX_INDEX + "INDEX (must be a positive integer) "
             + "[" + CliSyntax.PREFIX_NAME + "NAME DESCRIPTION] "
             + "[" + CliSyntax.PREFIX_COST + "COST] "
+            + "[" + CliSyntax.PREFIX_REMARK + "REMARK] "
             + "[" + CliSyntax.PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " " + CliSyntax.PREFIX_INDEX + "1 "
             + CliSyntax.PREFIX_NAME + "Mee Siam "

--- a/src/main/java/thrift/logic/commands/UpdateCommand.java
+++ b/src/main/java/thrift/logic/commands/UpdateCommand.java
@@ -18,6 +18,7 @@ import thrift.model.tag.Tag;
 import thrift.model.transaction.Description;
 import thrift.model.transaction.Expense;
 import thrift.model.transaction.Income;
+import thrift.model.transaction.Remark;
 import thrift.model.transaction.Transaction;
 import thrift.model.transaction.TransactionDate;
 import thrift.model.transaction.Value;
@@ -86,13 +87,14 @@ public class UpdateCommand extends Command {
         Description updatedDescription = updateTransactionDescriptor.getDescription()
                 .orElse(transactionToUpdate.getDescription());
         Value updatedValue = updateTransactionDescriptor.getValue().orElse(transactionToUpdate.getValue());
+        Remark updatedRemark = updateTransactionDescriptor.getRemark().orElse(transactionToUpdate.getRemark());
         TransactionDate updatedDate = updateTransactionDescriptor.getDate().orElse(transactionToUpdate.getDate());
         Set<Tag> updatedTags = updateTransactionDescriptor.getTags().orElse(transactionToUpdate.getTags());
 
         if (transactionToUpdate instanceof Expense) {
-            return new Expense(updatedDescription, updatedValue, updatedDate, updatedTags);
+            return new Expense(updatedDescription, updatedValue, updatedRemark, updatedDate, updatedTags);
         } else {
-            return new Income(updatedDescription, updatedValue, updatedDate, updatedTags);
+            return new Income(updatedDescription, updatedValue, updatedRemark, updatedDate, updatedTags);
         }
     }
 
@@ -121,6 +123,7 @@ public class UpdateCommand extends Command {
     public static class UpdateTransactionDescriptor {
         private Description description;
         private Value value;
+        private Remark remark;
         private TransactionDate date;
         private Set<Tag> tags;
 
@@ -133,6 +136,7 @@ public class UpdateCommand extends Command {
         public UpdateTransactionDescriptor(UpdateTransactionDescriptor toCopy) {
             setDescription(toCopy.description);
             setValue(toCopy.value);
+            setRemark(toCopy.remark);
             setDate(toCopy.date);
             setTags(toCopy.tags);
         }
@@ -141,7 +145,7 @@ public class UpdateCommand extends Command {
          * Returns true if at least one field is updated.
          */
         public boolean isAnyFieldUpdated() {
-            return CollectionUtil.isAnyNonNull(description, value, date, tags);
+            return CollectionUtil.isAnyNonNull(description, value, remark, date, tags);
         }
 
         public void setDescription(Description description) {
@@ -158,6 +162,14 @@ public class UpdateCommand extends Command {
 
         public Optional<Value> getValue() {
             return Optional.ofNullable(value);
+        }
+
+        public void setRemark(Remark remark) {
+            this.remark = remark;
+        }
+
+        public Optional<Remark> getRemark() {
+            return Optional.ofNullable(remark);
         }
 
         public void setDate(TransactionDate date) {
@@ -202,6 +214,7 @@ public class UpdateCommand extends Command {
 
             return getDescription().equals(e.getDescription())
                     && getValue().equals(e.getValue())
+                    && getRemark().equals(e.getRemark())
                     && getDate().equals(e.getDate())
                     && getTags().equals(e.getTags());
         }

--- a/src/main/java/thrift/logic/parser/AddExpenseCommandParser.java
+++ b/src/main/java/thrift/logic/parser/AddExpenseCommandParser.java
@@ -8,6 +8,7 @@ import thrift.logic.parser.exceptions.ParseException;
 import thrift.model.tag.Tag;
 import thrift.model.transaction.Description;
 import thrift.model.transaction.Expense;
+import thrift.model.transaction.Remark;
 import thrift.model.transaction.TransactionDate;
 import thrift.model.transaction.Value;
 
@@ -23,7 +24,8 @@ public class AddExpenseCommandParser extends AddTransactionCommandParser impleme
      */
     public AddExpenseCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_COST, CliSyntax.PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_COST,
+                        CliSyntax.PREFIX_REMARK, CliSyntax.PREFIX_TAG);
 
         if (!arePrefixesPresent(argMultimap, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_COST)
                 || !argMultimap.getPreamble().isEmpty()) {
@@ -33,10 +35,11 @@ public class AddExpenseCommandParser extends AddTransactionCommandParser impleme
 
         Description description = parseTransactionDescription(argMultimap);
         Value value = parseTransactionValue(argMultimap);
+        Remark remark = parseTransactionRemark(argMultimap);
         TransactionDate date = parseTransactionDate();
         Set<Tag> tagList = parseTransactionTags(argMultimap);
 
-        Expense expense = new Expense(description, value, date, tagList);
+        Expense expense = new Expense(description, value, remark, date, tagList);
 
         return new AddExpenseCommand(expense);
     }

--- a/src/main/java/thrift/logic/parser/AddIncomeCommandParser.java
+++ b/src/main/java/thrift/logic/parser/AddIncomeCommandParser.java
@@ -8,6 +8,7 @@ import thrift.logic.parser.exceptions.ParseException;
 import thrift.model.tag.Tag;
 import thrift.model.transaction.Description;
 import thrift.model.transaction.Income;
+import thrift.model.transaction.Remark;
 import thrift.model.transaction.TransactionDate;
 import thrift.model.transaction.Value;
 
@@ -23,7 +24,8 @@ public class AddIncomeCommandParser extends AddTransactionCommandParser implemen
      */
     public AddIncomeCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_COST, CliSyntax.PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_COST,
+                        CliSyntax.PREFIX_REMARK, CliSyntax.PREFIX_TAG);
 
         if (!arePrefixesPresent(argMultimap, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_COST)
                 || !argMultimap.getPreamble().isEmpty()) {
@@ -33,10 +35,11 @@ public class AddIncomeCommandParser extends AddTransactionCommandParser implemen
 
         Description description = parseTransactionDescription(argMultimap);
         Value value = parseTransactionValue(argMultimap);
+        Remark remark = parseTransactionRemark(argMultimap);
         TransactionDate date = parseTransactionDate();
         Set<Tag> tagList = parseTransactionTags(argMultimap);
 
-        Income income = new Income(description, value, date, tagList);
+        Income income = new Income(description, value, remark, date, tagList);
 
         return new AddIncomeCommand(income);
     }

--- a/src/main/java/thrift/logic/parser/AddTransactionCommandParser.java
+++ b/src/main/java/thrift/logic/parser/AddTransactionCommandParser.java
@@ -3,12 +3,14 @@ package thrift.logic.parser;
 import static thrift.model.transaction.TransactionDate.DATE_FORMATTER;
 
 import java.util.Date;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import thrift.logic.parser.exceptions.ParseException;
 import thrift.model.tag.Tag;
 import thrift.model.transaction.Description;
+import thrift.model.transaction.Remark;
 import thrift.model.transaction.TransactionDate;
 import thrift.model.transaction.Value;
 
@@ -44,6 +46,21 @@ public abstract class AddTransactionCommandParser {
      */
     protected Value parseTransactionValue(ArgumentMultimap argMultimap) throws ParseException {
         return ParserUtil.parseValue(argMultimap.getValue(CliSyntax.PREFIX_COST).get());
+    }
+
+    /**
+     * Parses for {@code Remark} object given the {@code ArgumentMultimap} object.
+     *
+    * @param argMultimap the object to parse from.
+    * @return {@code Remark} object based on the values in the input {@code ArgumentMultimap}.
+    */
+    protected Remark parseTransactionRemark(ArgumentMultimap argMultimap) {
+        Optional<String> remark = argMultimap.getValue(CliSyntax.PREFIX_REMARK);
+        if (remark.isEmpty()) {
+            return ParserUtil.parseRemark("");
+        } else {
+            return ParserUtil.parseRemark(remark.get());
+        }
     }
 
     /**

--- a/src/main/java/thrift/logic/parser/CliSyntax.java
+++ b/src/main/java/thrift/logic/parser/CliSyntax.java
@@ -10,5 +10,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_COST = new Prefix("c/");
     public static final Prefix PREFIX_INDEX = new Prefix("i/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
-
+    public static final Prefix PREFIX_REMARK = new Prefix("r/");
 }

--- a/src/main/java/thrift/logic/parser/ParserUtil.java
+++ b/src/main/java/thrift/logic/parser/ParserUtil.java
@@ -11,6 +11,7 @@ import thrift.commons.util.StringUtil;
 import thrift.logic.parser.exceptions.ParseException;
 import thrift.model.tag.Tag;
 import thrift.model.transaction.Description;
+import thrift.model.transaction.Remark;
 import thrift.model.transaction.Value;
 
 /**
@@ -23,6 +24,7 @@ public class ParserUtil {
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
+     *
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
@@ -36,7 +38,6 @@ public class ParserUtil {
     /**
      * Parses a {@code String description} into a {@code Description}.
      * Leading and trailing whitespaces will be trimmed.
-     *
      */
     public static Description parseDescription(String description) {
         requireNonNull(description);
@@ -57,6 +58,16 @@ public class ParserUtil {
             throw new ParseException(Value.VALUE_CONSTRAINTS);
         }
         return new Value(trimmedValue);
+    }
+
+    /**
+     * Parses a {@code String remark} into a {@code Remark}.
+     * Leading and trailing whitespaces will be trimmed.
+     */
+    public static Remark parseRemark(String remark) {
+        requireNonNull(remark);
+        String trimmedRemark = remark.trim();
+        return new Remark(trimmedRemark);
     }
 
     /**

--- a/src/main/java/thrift/logic/parser/UpdateCommandParser.java
+++ b/src/main/java/thrift/logic/parser/UpdateCommandParser.java
@@ -27,7 +27,7 @@ public class UpdateCommandParser implements Parser<UpdateCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_INDEX, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_COST,
-                        CliSyntax.PREFIX_TAG);
+                        CliSyntax.PREFIX_REMARK, CliSyntax.PREFIX_TAG);
 
         Index index;
 
@@ -48,6 +48,12 @@ public class UpdateCommandParser implements Parser<UpdateCommand> {
         if (argMultimap.getValue(CliSyntax.PREFIX_COST).isPresent()) {
             updateTransactionDescriptor.setValue(ParserUtil.parseValue(
                     argMultimap.getValue(CliSyntax.PREFIX_COST).get()));
+        }
+
+        if (argMultimap.getValue(CliSyntax.PREFIX_REMARK).isPresent()) {
+            updateTransactionDescriptor.setRemark(ParserUtil.parseRemark(
+                    argMultimap.getValue(CliSyntax.PREFIX_REMARK).get()
+            ));
         }
 
         parseTagsForUpdate(argMultimap.getAllValues(CliSyntax.PREFIX_TAG))

--- a/src/main/java/thrift/model/transaction/Expense.java
+++ b/src/main/java/thrift/model/transaction/Expense.java
@@ -17,15 +17,17 @@ public class Expense extends Transaction {
     private final Description description;
     private final TransactionDate date;
     private final Value value;
+    private final Remark remark;
     private final Set<Tag> tags = new HashSet<>();
 
     /**
      * Every field must be present and not null.
      */
-    public Expense(Description description, Value value, TransactionDate date, Set<Tag> tags) {
+    public Expense(Description description, Value value, Remark remark, TransactionDate date, Set<Tag> tags) {
         this.description = description;
-        this.date = date;
         this.value = value;
+        this.remark = remark;
+        this.date = date;
         this.tags.addAll(tags);
     }
 
@@ -39,6 +41,10 @@ public class Expense extends Transaction {
 
     public Value getValue() {
         return value;
+    }
+
+    public Remark getRemark() {
+        return remark;
     }
 
     /**
@@ -77,6 +83,7 @@ public class Expense extends Transaction {
         return otherExpense.getDescription().equals(getDescription())
                 && otherExpense.getDate().equals(getDate())
                 && otherExpense.getValue().equals(getValue())
+                && otherExpense.getRemark().equals(getRemark())
                 && otherExpense.getTags().equals(getTags());
     }
 
@@ -95,6 +102,8 @@ public class Expense extends Transaction {
                 .append(getValue())
                 .append(") Date: ")
                 .append(getDate())
+                .append(" Remarks: ")
+                .append(getRemark())
                 .append(" Tags: ");
         getTags().forEach(builder::append);
         return builder.toString();

--- a/src/main/java/thrift/model/transaction/Income.java
+++ b/src/main/java/thrift/model/transaction/Income.java
@@ -17,15 +17,17 @@ public class Income extends Transaction {
     private final Description description;
     private final TransactionDate date;
     private final Value value;
+    private final Remark remark;
     private final Set<Tag> tags = new HashSet<>();
 
     /**
      * Every field must be present and not null.
      */
-    public Income(Description description, Value value, TransactionDate date, Set<Tag> tags) {
+    public Income(Description description, Value value, Remark remark, TransactionDate date, Set<Tag> tags) {
         this.description = description;
-        this.date = date;
         this.value = value;
+        this.remark = remark;
+        this.date = date;
         this.tags.addAll(tags);
     }
 
@@ -39,6 +41,10 @@ public class Income extends Transaction {
 
     public Value getValue() {
         return value;
+    }
+
+    public Remark getRemark() {
+        return remark;
     }
 
     /**
@@ -77,6 +83,7 @@ public class Income extends Transaction {
         return otherIncome.getDescription().equals(getDescription())
                 && otherIncome.getDate().equals(getDate())
                 && otherIncome.getValue().equals(getValue())
+                && otherIncome.getRemark().equals(getRemark())
                 && otherIncome.getTags().equals(getTags());
     }
 
@@ -95,6 +102,8 @@ public class Income extends Transaction {
                 .append(getValue())
                 .append(") Date: ")
                 .append(getDate())
+                .append(" Remarks: ")
+                .append(getRemark())
                 .append(" Tags: ");
         getTags().forEach(builder::append);
         return builder.toString();

--- a/src/main/java/thrift/model/transaction/Remark.java
+++ b/src/main/java/thrift/model/transaction/Remark.java
@@ -1,0 +1,40 @@
+package thrift.model.transaction;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Represents a Transaction's remark which is optional.
+ * Guarantees: immutable.
+ */
+public class Remark {
+
+    public final String value;
+
+    /**
+     * Constructs a {@code Remark}.
+     *
+     * @param remark Remark describing the Transaction.
+     */
+    public Remark(String remark) {
+        requireNonNull(remark);
+        value = remark;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Remark // instanceof handles nulls
+                && value.equals(((Remark) other).value)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+}

--- a/src/main/java/thrift/model/transaction/Transaction.java
+++ b/src/main/java/thrift/model/transaction/Transaction.java
@@ -37,6 +37,13 @@ public abstract class Transaction {
     public abstract Value getValue();
 
     /**
+     * Gets this Transaction object's Remark.
+     *
+     * @return This Transaction object's Remark.
+     */
+    public abstract Remark getRemark();
+
+    /**
      * Gets this Transaction object's set of Tag.
      *
      * @return Set&lt;Tag&gt; belonging to this Transaction object.

--- a/src/main/java/thrift/model/util/SampleDataUtil.java
+++ b/src/main/java/thrift/model/util/SampleDataUtil.java
@@ -10,6 +10,7 @@ import thrift.model.tag.Tag;
 import thrift.model.transaction.Description;
 import thrift.model.transaction.Expense;
 import thrift.model.transaction.Income;
+import thrift.model.transaction.Remark;
 import thrift.model.transaction.Transaction;
 import thrift.model.transaction.TransactionDate;
 import thrift.model.transaction.Value;
@@ -20,12 +21,12 @@ import thrift.model.transaction.Value;
 public class SampleDataUtil {
     public static Transaction[] getSampleTransaction() {
         return new Transaction[] {
-            new Expense(new Description("Laksa"), new Value("3.50"), new TransactionDate("13/03/1937"),
+            new Expense(new Description("Laksa"), new Value("3.50"), new Remark(""), new TransactionDate("13/03/1937"),
                     getTagSet("Lunch")),
             new Expense(new Description("Airpods 2nd Generation"), new Value("300"),
-                    new TransactionDate("14/03/1937"), getTagSet("Accessory")),
-            new Income(new Description("Bursary"), new Value("500"), new TransactionDate("12/03/1937"),
-                    getTagSet("Award"))
+                    new Remark("Good buy!"), new TransactionDate("14/03/1937"), getTagSet("Accessory")),
+            new Income(new Description("Bursary"), new Value("500"), new Remark("I worked hard."),
+                    new TransactionDate("12/03/1937"), getTagSet("Award"))
         };
     }
 

--- a/src/main/java/thrift/storage/JsonAdaptedTransaction.java
+++ b/src/main/java/thrift/storage/JsonAdaptedTransaction.java
@@ -14,6 +14,7 @@ import thrift.model.tag.Tag;
 import thrift.model.transaction.Description;
 import thrift.model.transaction.Expense;
 import thrift.model.transaction.Income;
+import thrift.model.transaction.Remark;
 import thrift.model.transaction.Transaction;
 import thrift.model.transaction.TransactionDate;
 import thrift.model.transaction.Value;
@@ -28,6 +29,7 @@ class JsonAdaptedTransaction {
     private final String type;
     private final String description;
     private final String value;
+    private final String remark;
     private final String date;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
 
@@ -36,11 +38,12 @@ class JsonAdaptedTransaction {
      */
     @JsonCreator
     public JsonAdaptedTransaction(@JsonProperty("type") String type, @JsonProperty("description") String description,
-            @JsonProperty("value") String value, @JsonProperty("date") String date,
-            @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+            @JsonProperty("value") String value, @JsonProperty("remark") String remark,
+            @JsonProperty("date") String date, @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
         this.type = type;
         this.description = description;
         this.value = value;
+        this.remark = remark;
         this.date = date;
         if (tagged != null) {
             this.tagged.addAll(tagged);
@@ -58,6 +61,7 @@ class JsonAdaptedTransaction {
         }
         description = source.getDescription().toString();
         value = source.getValue().getUnformattedString();
+        remark = source.getRemark().toString();
         date = source.getDate().toString();
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
@@ -96,6 +100,12 @@ class JsonAdaptedTransaction {
         }
         final Value modelValue = new Value(value);
 
+        if (remark == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    Remark.class.getSimpleName()));
+        }
+        final Remark modelRemark = new Remark(remark);
+
         if (date == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     TransactionDate.class.getSimpleName()));
@@ -108,9 +118,9 @@ class JsonAdaptedTransaction {
         final Set<Tag> modelTags = new HashSet<>(transactionTags);
 
         if (modelType.equals("expense")) {
-            return new Expense(modelDescription, modelValue, modelDate, modelTags);
+            return new Expense(modelDescription, modelValue, modelRemark, modelDate, modelTags);
         } else {
-            return new Income(modelDescription, modelValue, modelDate, modelTags);
+            return new Income(modelDescription, modelValue, modelRemark, modelDate, modelTags);
         }
     }
 

--- a/src/main/java/thrift/ui/ExpenseTransactionCard.java
+++ b/src/main/java/thrift/ui/ExpenseTransactionCard.java
@@ -37,7 +37,7 @@ public class ExpenseTransactionCard extends UiPart<Region> {
     @FXML
     private Label expenseDate;
     @FXML
-    private Label expenseReserved;
+    private Label expenseRemark;
     @FXML
     private FlowPane tags;
 
@@ -48,13 +48,13 @@ public class ExpenseTransactionCard extends UiPart<Region> {
         expenseDescription.setText(transaction.getDescription().toString());
         expenseValue.setText("-$" + transaction.getValue().toString());
         expenseDate.setText(transaction.getDate().toString());
-        expenseReserved.setText("Dummy text label in ExpenseTransactionCard.java.");
+        expenseRemark.setText(transaction.getRemark().toString());
         transaction.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
         expenseDescription.setWrapText(true);
         expenseValue.setWrapText(true);
-        expenseReserved.setWrapText(true);
+        expenseRemark.setWrapText(true);
     }
 
     @Override

--- a/src/main/java/thrift/ui/IncomeTransactionCard.java
+++ b/src/main/java/thrift/ui/IncomeTransactionCard.java
@@ -37,7 +37,7 @@ public class IncomeTransactionCard extends UiPart<Region> {
     @FXML
     private Label incomeDate;
     @FXML
-    private Label incomeReserved;
+    private Label incomeRemark;
     @FXML
     private FlowPane tags;
 
@@ -48,13 +48,13 @@ public class IncomeTransactionCard extends UiPart<Region> {
         incomeDescription.setText(transaction.getDescription().toString());
         incomeValue.setText("$" + transaction.getValue().toString());
         incomeDate.setText(transaction.getDate().toString());
-        incomeReserved.setText("Dummy text label in IncomeTransactionCard.java.");
+        incomeRemark.setText(transaction.getRemark().toString());
         transaction.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
         incomeDescription.setWrapText(true);
         incomeValue.setWrapText(true);
-        incomeReserved.setWrapText(true);
+        incomeRemark.setWrapText(true);
     }
 
     @Override

--- a/src/main/resources/view/ExpenseTransactionCard.fxml
+++ b/src/main/resources/view/ExpenseTransactionCard.fxml
@@ -32,7 +32,11 @@
           </HBox>
           <FlowPane fx:id="tags" />
           <Label fx:id="expenseDate" styleClass="cell_small_label" text="\$date" />
-          <Label fx:id="expenseReserved" styleClass="cell_small_label" text="\$reserved" />
+          <HBox>
+            <Label id="remark" styleClass="cell_small_label">Remarks:</Label>
+            <Label minWidth="3" />
+            <Label fx:id="expenseRemark" styleClass="cell_small_label" text="\$reserved" />
+          </HBox>
         </VBox>
         <Pane HBox.hgrow="ALWAYS"></Pane>
         <Label fx:id="expenseValue" styleClass="cell_small_label" text="\$value" />

--- a/src/main/resources/view/IncomeTransactionCard.fxml
+++ b/src/main/resources/view/IncomeTransactionCard.fxml
@@ -32,7 +32,11 @@
                     </HBox>
                     <FlowPane fx:id="tags" />
                     <Label fx:id="incomeDate" styleClass="cell_small_label" text="\$date" />
-                    <Label fx:id="incomeReserved" styleClass="cell_small_label" text="\$reserved" />
+                    <HBox>
+                      <Label styleClass="cell_small_label">Remarks:</Label>
+                      <Label minWidth="3" />
+                      <Label fx:id="incomeRemark" styleClass="cell_small_label" text="\$reserved" />
+                    </HBox>
                 </VBox>
                 <Pane HBox.hgrow="ALWAYS" minWidth="50"></Pane>
                 <Label fx:id="incomeValue" styleClass="cell_small_label" text="\$value" />

--- a/src/test/java/thrift/logic/commands/CommandTestUtil.java
+++ b/src/test/java/thrift/logic/commands/CommandTestUtil.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static thrift.logic.parser.CliSyntax.PREFIX_COST;
 import static thrift.logic.parser.CliSyntax.PREFIX_INDEX;
 import static thrift.logic.parser.CliSyntax.PREFIX_NAME;
+import static thrift.logic.parser.CliSyntax.PREFIX_REMARK;
 import static thrift.logic.parser.CliSyntax.PREFIX_TAG;
 import static thrift.testutil.Assert.assertThrows;
 
@@ -32,6 +33,7 @@ public class CommandTestUtil {
     public static final String VALID_VALUE_BURSARY = "500";
     public static final String VALID_VALUE_LAKSA = "3.50";
     public static final String VALID_VALUE_AIRPODS = "350";
+    public static final String VALID_REMARK_LAKSA = "Delicious!";
     public static final String VALID_DATE_BURSARY = "09/10/2019";
     public static final String VALID_DATE_LAKSA = "13/03/1937";
     public static final String VALID_DATE_AIRPODS = "14/03/1937";
@@ -45,6 +47,7 @@ public class CommandTestUtil {
     public static final String DESC_AIRPODS = " " + PREFIX_NAME + VALID_DESCRIPTION_AIRPODS;
     public static final String VALUE_BURSARY = " " + PREFIX_COST + VALID_VALUE_BURSARY;
     public static final String VALUE_LAKSA = " " + PREFIX_COST + VALID_VALUE_LAKSA;
+    public static final String REMARK_LAKSA = " " + PREFIX_REMARK + VALID_REMARK_LAKSA;
     public static final String VALUE_AIRPODS = " " + PREFIX_COST + VALID_VALUE_AIRPODS;
     public static final String TAG_BURSARY = " " + PREFIX_TAG + VALID_TAG_AWARD;
     public static final String TAG_LAKSA = " " + PREFIX_TAG + VALID_TAG_LUNCH;

--- a/src/test/java/thrift/logic/parser/AddExpenseCommandParserTest.java
+++ b/src/test/java/thrift/logic/parser/AddExpenseCommandParserTest.java
@@ -17,12 +17,13 @@ public class AddExpenseCommandParserTest {
     public void parse_allFieldsPresent_success() {
         // whitespace only preamble
         assertDoesNotThrow(() -> parser.parse(CommandTestUtil.PREAMBLE_WHITESPACE
-                + CommandTestUtil.DESC_LAKSA + CommandTestUtil.VALUE_LAKSA
+                + CommandTestUtil.DESC_LAKSA + CommandTestUtil.VALUE_LAKSA + CommandTestUtil.REMARK_LAKSA
                 + CommandTestUtil.TAG_LAKSA));
 
         // multiple tags - all accepted
         assertDoesNotThrow(() -> parser.parse(CommandTestUtil.DESC_LAKSA
-                + CommandTestUtil.VALUE_LAKSA + CommandTestUtil.TAG_LAKSA + CommandTestUtil.TAG_BRUNCH));
+                + CommandTestUtil.VALUE_LAKSA + CommandTestUtil.REMARK_LAKSA
+                + CommandTestUtil.TAG_LAKSA + CommandTestUtil.TAG_BRUNCH));
     }
 
     @Test

--- a/src/test/java/thrift/logic/parser/AddIncomeCommandParserTest.java
+++ b/src/test/java/thrift/logic/parser/AddIncomeCommandParserTest.java
@@ -18,12 +18,12 @@ public class AddIncomeCommandParserTest {
     public void parse_allFieldsPresent_success() {
         // whitespace only preamble
         assertDoesNotThrow(() -> parser.parse(CommandTestUtil.PREAMBLE_WHITESPACE
-                + CommandTestUtil.DESC_BURSARY + CommandTestUtil.VALUE_BURSARY
+                + CommandTestUtil.DESC_BURSARY + CommandTestUtil.VALUE_BURSARY + CommandTestUtil.REMARK_LAKSA
                 + CommandTestUtil.TAG_BURSARY));
 
         // multiple tags - all accepted
         assertDoesNotThrow(() -> parser.parse(CommandTestUtil.DESC_BURSARY + CommandTestUtil.VALUE_BURSARY
-                + CommandTestUtil.TAG_BURSARY + CommandTestUtil.TAG_AIRPODS));
+                + CommandTestUtil.REMARK_LAKSA + CommandTestUtil.TAG_BURSARY + CommandTestUtil.TAG_AIRPODS));
     }
 
     @Test

--- a/src/test/java/thrift/model/transaction/RemarkTest.java
+++ b/src/test/java/thrift/model/transaction/RemarkTest.java
@@ -1,0 +1,14 @@
+package thrift.model.transaction;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class RemarkTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Remark(null));
+    }
+
+}

--- a/src/test/java/thrift/storage/JsonAdaptedTransactionTest.java
+++ b/src/test/java/thrift/storage/JsonAdaptedTransactionTest.java
@@ -22,6 +22,7 @@ public class JsonAdaptedTransactionTest {
     private static final String VALID_TYPE = "expense";
     private static final String VALID_DESCRIPTION = TypicalTransactions.LAKSA.getDescription().toString();
     private static final String VALID_VALUE = TypicalTransactions.LAKSA.getValue().toString();
+    private static final String VALID_REMARK = "This is valid!";
     private static final String VALID_DATE = "10/10/2010";
     private static final List<JsonAdaptedTag> VALID_TAGS = TypicalTransactions.LAKSA.getTags().stream()
             .map(JsonAdaptedTag::new)
@@ -37,7 +38,8 @@ public class JsonAdaptedTransactionTest {
     @Test
     public void toModelType_nullDescription_throwsIllegalValueException() {
         JsonAdaptedTransaction transaction =
-                new JsonAdaptedTransaction(VALID_TYPE, null, VALID_VALUE, VALID_DATE, VALID_TAGS);
+                new JsonAdaptedTransaction(VALID_TYPE, null, VALID_VALUE,
+                        VALID_REMARK, VALID_DATE, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Description.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, transaction::toModelType);
     }
@@ -45,7 +47,8 @@ public class JsonAdaptedTransactionTest {
     @Test
     public void toModelType_invalidValue_throwsIllegalValueException() {
         JsonAdaptedTransaction transaction =
-                new JsonAdaptedTransaction(VALID_TYPE, VALID_DESCRIPTION, INVALID_VALUE, VALID_DATE, VALID_TAGS);
+                new JsonAdaptedTransaction(VALID_TYPE, VALID_DESCRIPTION, INVALID_VALUE,
+                        VALID_REMARK, VALID_DATE, VALID_TAGS);
         String expectedMessage = Value.VALUE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, transaction::toModelType);
     }
@@ -53,7 +56,8 @@ public class JsonAdaptedTransactionTest {
     @Test
     public void toModelType_nullValue_throwsIllegalValueException() {
         JsonAdaptedTransaction transaction =
-                new JsonAdaptedTransaction(VALID_TYPE, VALID_DESCRIPTION, null, VALID_DATE, VALID_TAGS);
+                new JsonAdaptedTransaction(VALID_TYPE, VALID_DESCRIPTION, null,
+                        VALID_REMARK, VALID_DATE, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Value.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, transaction::toModelType);
     }
@@ -63,7 +67,8 @@ public class JsonAdaptedTransactionTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedTransaction transaction =
-                new JsonAdaptedTransaction(VALID_TYPE, VALID_DESCRIPTION, VALID_VALUE, VALID_DATE, invalidTags);
+                new JsonAdaptedTransaction(VALID_TYPE, VALID_DESCRIPTION, VALID_VALUE,
+                        VALID_REMARK, VALID_DATE, invalidTags);
         assertThrows(IllegalValueException.class, transaction::toModelType);
     }
 

--- a/src/test/java/thrift/testutil/ExpenseBuilder.java
+++ b/src/test/java/thrift/testutil/ExpenseBuilder.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import thrift.model.tag.Tag;
 import thrift.model.transaction.Description;
 import thrift.model.transaction.Expense;
+import thrift.model.transaction.Remark;
 import thrift.model.transaction.Transaction;
 import thrift.model.transaction.TransactionDate;
 import thrift.model.transaction.Value;
@@ -18,16 +19,19 @@ public class ExpenseBuilder {
 
     public static final String DEFAULT_DESCRIPTION = "Laksa";
     public static final String DEFAULT_COST = "3.50";
+    public static final String DEFAULT_REMARK = "One of the best Laksa";
     public static final String DEFAULT_DATE = "13/03/1937";
 
     private Description description;
     private Value value;
+    private Remark remark;
     private TransactionDate date;
     private Set<Tag> tags;
 
     public ExpenseBuilder() {
         description = new Description(DEFAULT_DESCRIPTION);
         value = new Value(DEFAULT_COST);
+        remark = new Remark(DEFAULT_REMARK);
         date = new TransactionDate(DEFAULT_DATE);
         tags = new HashSet<>();
     }
@@ -38,6 +42,7 @@ public class ExpenseBuilder {
     public ExpenseBuilder(Transaction transactionToCopy) {
         description = transactionToCopy.getDescription();
         value = transactionToCopy.getValue();
+        remark = transactionToCopy.getRemark();
         date = transactionToCopy.getDate();
         tags = new HashSet<>(transactionToCopy.getTags());
     }
@@ -67,6 +72,14 @@ public class ExpenseBuilder {
     }
 
     /**
+     * Sets the {@code Remark} of the {@code Expense} that we are building.
+     */
+    public ExpenseBuilder withRemark(String remark) {
+        this.remark = new Remark(remark);
+        return this;
+    }
+
+    /**
      * Sets the {@code TransactionDate} of the {@code Expense} that we are building.
      */
     public ExpenseBuilder withDate(String date) {
@@ -75,7 +88,7 @@ public class ExpenseBuilder {
     }
 
     public Expense build() {
-        return new Expense(description, value, date, tags);
+        return new Expense(description, value, remark, date, tags);
     }
 
 }

--- a/src/test/java/thrift/testutil/IncomeBuilder.java
+++ b/src/test/java/thrift/testutil/IncomeBuilder.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import thrift.model.tag.Tag;
 import thrift.model.transaction.Description;
 import thrift.model.transaction.Income;
+import thrift.model.transaction.Remark;
 import thrift.model.transaction.Transaction;
 import thrift.model.transaction.TransactionDate;
 import thrift.model.transaction.Value;
@@ -22,12 +23,14 @@ public class IncomeBuilder {
 
     private Description description;
     private Value value;
+    private Remark remark;
     private TransactionDate date;
     private Set<Tag> tags;
 
     public IncomeBuilder() {
         description = new Description(DEFAULT_DESCRIPTION);
         value = new Value(DEFAULT_COST);
+        remark = new Remark("");
         date = new TransactionDate(DEFAULT_DATE);
         tags = new HashSet<>();
     }
@@ -38,6 +41,7 @@ public class IncomeBuilder {
     public IncomeBuilder(Transaction transactionToCopy) {
         description = transactionToCopy.getDescription();
         value = transactionToCopy.getValue();
+        remark = transactionToCopy.getRemark();
         date = transactionToCopy.getDate();
         tags = new HashSet<>(transactionToCopy.getTags());
     }
@@ -67,6 +71,16 @@ public class IncomeBuilder {
     }
 
     /**
+     * Sets the {@code Remark} of the {@code Income} that we are building.
+     * @param remark
+     * @return
+     */
+    public IncomeBuilder withRemark(String remark) {
+        this.remark = new Remark(remark);
+        return this;
+    }
+
+    /**
      * Sets the {@code TransactionDate} of the {@code Income} that we are building.
      */
     public IncomeBuilder withDate(String date) {
@@ -75,7 +89,7 @@ public class IncomeBuilder {
     }
 
     public Income build() {
-        return new Income(description, value, date, tags);
+        return new Income(description, value, remark, date, tags);
     }
 
 }

--- a/src/test/java/thrift/testutil/TypicalTransactions.java
+++ b/src/test/java/thrift/testutil/TypicalTransactions.java
@@ -17,7 +17,7 @@ public class TypicalTransactions {
     public static final Expense LAKSA = new ExpenseBuilder().withDescription("Laksa").withValue("3.50")
             .withDate("13/03/1937").withTags("Lunch").build();
     public static final Expense PENANG_LAKSA = new ExpenseBuilder().withDescription("Penang Laksa1").withValue("5")
-            .withDate("11/10/2010").withTags("Brunch").build();
+            .withDate("11/10/2010").withRemark("One of the best Laksa").withTags("Brunch").build();
     public static final Income BURSARY = new IncomeBuilder().withDescription("Bursary").withValue("500")
             .withDate("13/11/2011").withTags("Award").build();
 

--- a/src/test/java/thrift/testutil/UpdateTransactionDescriptorBuilder.java
+++ b/src/test/java/thrift/testutil/UpdateTransactionDescriptorBuilder.java
@@ -8,6 +8,7 @@ import thrift.logic.commands.UpdateCommand;
 import thrift.logic.commands.UpdateCommand.UpdateTransactionDescriptor;
 import thrift.model.tag.Tag;
 import thrift.model.transaction.Description;
+import thrift.model.transaction.Remark;
 import thrift.model.transaction.Transaction;
 import thrift.model.transaction.TransactionDate;
 import thrift.model.transaction.Value;
@@ -34,6 +35,7 @@ public class UpdateTransactionDescriptorBuilder {
         descriptor = new UpdateTransactionDescriptor();
         descriptor.setDescription(transaction.getDescription());
         descriptor.setValue(transaction.getValue());
+        descriptor.setRemark(transaction.getRemark());
         descriptor.setDate(transaction.getDate());
         descriptor.setTags(transaction.getTags());
     }
@@ -51,6 +53,14 @@ public class UpdateTransactionDescriptorBuilder {
      */
     public UpdateTransactionDescriptorBuilder withValue(String value) {
         descriptor.setValue(new Value(value));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Remark} of the {@code UpdateTransactionDescriptor} that we are building.
+     */
+    public UpdateTransactionDescriptorBuilder withRemark(String remark) {
+        descriptor.setRemark(new Remark(remark));
         return this;
     }
 


### PR DESCRIPTION
1. Updated `AddExpenseCommandParser`, `AddIncomeCommandParser` and `UpdateCommandParser` to work with the new field.
2. Updated UI `Transaction` cards to display the `Remark` value.
3. Updated all relevant tests and made test for `Remark`.
4. Updated `JsonAdaptedTransaction` to ensure that the new field is saved and restored properly.
5. Updated UG and fixed the output for `add_expense` and `add_income` portions.

Resolves #105 