### PR TITLE
Tag/Untag index bug fix

### DIFF
--- a/src/main/java/thrift/logic/commands/TagCommand.java
+++ b/src/main/java/thrift/logic/commands/TagCommand.java
@@ -78,7 +78,7 @@ public class TagCommand extends Command {
                 ? ""
                 : String.format(MESSAGE_TAG_EXISTED, existedTags.toString());
 
-        model.setTransaction(transactionToTag, updatedTransaction);
+        model.setTransactionWithIndex(index, updatedTransaction);
         model.updateFilteredTransactionList(Model.PREDICATE_SHOW_ALL_TRANSACTIONS);
 
         return new CommandResult(taggedTransactionNotification

--- a/src/main/java/thrift/logic/commands/UntagCommand.java
+++ b/src/main/java/thrift/logic/commands/UntagCommand.java
@@ -78,7 +78,7 @@ public class UntagCommand extends Command {
                 ? ""
                 : String.format(MESSAGE_TAG_NOT_EXISTED, nonexistentTags.toString());
 
-        model.setTransaction(transactionToTag, updatedTransaction);
+        model.setTransactionWithIndex(index, updatedTransaction);
         model.updateFilteredTransactionList(Model.PREDICATE_SHOW_ALL_TRANSACTIONS);
         return new CommandResult(taggedTransactionNotification
                 + nonexistentTagsNotification


### PR DESCRIPTION
Fixes a bug that causes `Tag`/`Untag` commands to select the wrong transaction (always the first occurrence) amongst similar ones to tag/untag.

Fixes #136