### PR TITLE
Added support for scrolling into newly added Transaction if it exists in the current view

### DIFF
--- a/src/main/java/thrift/logic/Logic.java
+++ b/src/main/java/thrift/logic/Logic.java
@@ -38,7 +38,52 @@ public interface Logic {
      */
     ReadOnlyThrift getThrift();
 
-    /** Returns if the given command requires a refresh of the filteredlist. */
+    /**
+     * Processes the parsed command, checking if it requires scrolling the view, updating the balancebar, or record
+     * keeping for possible undo/redo.
+     *
+     * @param command processed command that is ready to execute.
+     * @param commandText raw user input for the command.
+     * @param transactionListPanel transaction list pane that houses the transactions displayed to the user.
+     * @param balanceBar GUI object that displays the current balance, budget and month to the user.
+     * @return {@code CommandResult} object that is created as a result from executing the command.
+     * @throws CommandException if the command encounters any runtime errors.
+     */
+    CommandResult processParsedCommand(Command command, String commandText, TransactionListPanel transactionListPanel,
+                                       BalanceBar balanceBar) throws CommandException;
+
+    /**
+     * Takes the given command and executes it, checking if the command requires scrolling the
+     * {@code transactionListPanel} into view.
+     *
+     * @param command processed command that is ready to execute.
+     * @param transactionListPanel transaction list pane that houses the transactions displayed to the user.
+     * @return {@code CommandResult} object that is created as a result from executing the command.
+     * @throws CommandException if the command encounters any runtime errors.
+     */
+    CommandResult parseScrollable(Command command, TransactionListPanel transactionListPanel)
+            throws CommandException;
+
+    /**
+     * Checks if the given command requires the {@code BalanceBar} to be refreshed.
+     *
+     * @param command processed command that is ready to execute.
+     * @param balanceBar GUI object that displays the current balance, budget and month to the user.
+     */
+    void parseRefreshable(Command command, BalanceBar balanceBar);
+
+    /**
+     * Checks if the given command requires to be record-kept for possible undo/redo in the future.
+     *
+     * @param command processed command that is ready to execute.
+     * @param commandText raw user input for the command.
+     */
+    void parseUndoable(Command command, String commandText);
+
+    /** Updates the various components of the {@code BalnaceBar}. */
+    void updateBalanceBar(BalanceBar balanceBar);
+
+    /** Returns if the given command requires a refresh of the {@code filteredList}. */
     boolean isRefreshingFilteredList(Command command);
 
     /** Returns the current month and year in MMM yyyy format. */

--- a/src/main/java/thrift/logic/commands/AddExpenseCommand.java
+++ b/src/main/java/thrift/logic/commands/AddExpenseCommand.java
@@ -6,11 +6,12 @@ import static thrift.commons.util.CollectionUtil.requireAllNonNull;
 import thrift.logic.parser.CliSyntax;
 import thrift.model.Model;
 import thrift.model.transaction.Expense;
+import thrift.ui.TransactionListPanel;
 
 /**
  * Adds an expense transaction to the THRIFT.
  */
-public class AddExpenseCommand extends NonScrollingCommand implements Undoable {
+public class AddExpenseCommand extends ScrollingCommand implements Undoable {
 
     public static final String COMMAND_WORD = "add_expense";
 
@@ -40,9 +41,15 @@ public class AddExpenseCommand extends NonScrollingCommand implements Undoable {
     }
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model, TransactionListPanel transactionListPanel) {
         requireNonNull(model);
         model.addExpense(toAdd);
+
+        // Use null comparison instead of requireNonNull(transactionListPanel) as current JUnit tests are unable to
+        // handle JavaFX initialization
+        if (model.isInView(toAdd) && transactionListPanel != null) {
+            transactionListPanel.getTransactionListView().scrollTo(toAdd);
+        }
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/thrift/logic/commands/AddIncomeCommand.java
+++ b/src/main/java/thrift/logic/commands/AddIncomeCommand.java
@@ -6,11 +6,12 @@ import static thrift.commons.util.CollectionUtil.requireAllNonNull;
 import thrift.logic.parser.CliSyntax;
 import thrift.model.Model;
 import thrift.model.transaction.Income;
+import thrift.ui.TransactionListPanel;
 
 /**
  * Adds an expense transaction to the THRIFT.
  */
-public class AddIncomeCommand extends NonScrollingCommand implements Undoable {
+public class AddIncomeCommand extends ScrollingCommand implements Undoable {
 
     public static final String COMMAND_WORD = "add_income";
 
@@ -39,9 +40,15 @@ public class AddIncomeCommand extends NonScrollingCommand implements Undoable {
     }
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model, TransactionListPanel transactionListPanel) {
         requireNonNull(model);
         model.addIncome(toAdd);
+
+        // Use null comparison instead of requireNonNull(transactionListPanel) as current JUnit tests are unable to
+        // handle JavaFX initialization
+        if (model.isInView(toAdd) && transactionListPanel != null) {
+            transactionListPanel.getTransactionListView().scrollTo(toAdd);
+        }
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/thrift/model/Model.java
+++ b/src/main/java/thrift/model/Model.java
@@ -161,6 +161,11 @@ public interface Model {
     double getBalance();
 
     /**
+     * Returns if {@code transaction} is currently in {@code FilteredList<Transaction>}.
+     */
+    boolean isInView(Transaction transaction);
+
+    /**
      * Keeps track of past undoable commands.
      */
     void keepTrackCommands(Undoable command);

--- a/src/main/java/thrift/model/ModelManager.java
+++ b/src/main/java/thrift/model/ModelManager.java
@@ -248,6 +248,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean isInView(Transaction transaction) {
+        return filteredTransactions.contains(transaction);
+    }
+
+    @Override
     public boolean equals(Object obj) {
         // short circuit if same object
         if (obj == this) {

--- a/src/test/java/thrift/logic/commands/AddExpenseCommandTest.java
+++ b/src/test/java/thrift/logic/commands/AddExpenseCommandTest.java
@@ -43,7 +43,7 @@ public class AddExpenseCommandTest {
         ModelStubAcceptingTransactionAdded modelStub = new ModelStubAcceptingTransactionAdded();
         Expense validExpense = new ExpenseBuilder().build();
 
-        CommandResult commandResult = new AddExpenseCommand(validExpense).execute(modelStub);
+        CommandResult commandResult = new AddExpenseCommand(validExpense).execute(modelStub, null);
 
         assertEquals(String.format(AddExpenseCommand.MESSAGE_SUCCESS, validExpense), commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validExpense), modelStub.transactionsAdded);
@@ -260,6 +260,11 @@ public class AddExpenseCommandTest {
         }
 
         @Override
+        public boolean isInView(Transaction transaction) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void keepTrackCommands(Undoable command) {
             throw new AssertionError("This method should not be called.");
         }
@@ -319,6 +324,11 @@ public class AddExpenseCommandTest {
         public void addExpense(Expense expense) {
             requireNonNull(expense);
             transactionsAdded.add(expense);
+        }
+
+        @Override
+        public boolean isInView(Transaction transaction) {
+            return transactionsAdded.contains(transaction);
         }
 
         @Override

--- a/src/test/java/thrift/logic/commands/AddIncomeCommandTest.java
+++ b/src/test/java/thrift/logic/commands/AddIncomeCommandTest.java
@@ -43,7 +43,7 @@ public class AddIncomeCommandTest {
         ModelStubAcceptingTransactionAdded modelStub = new ModelStubAcceptingTransactionAdded();
         Income validIncome = new IncomeBuilder().build();
 
-        CommandResult commandResult = new AddIncomeCommand(validIncome).execute(modelStub);
+        CommandResult commandResult = new AddIncomeCommand(validIncome).execute(modelStub, null);
 
         assertEquals(String.format(AddIncomeCommand.MESSAGE_SUCCESS, validIncome), commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validIncome), modelStub.transactionsAdded);
@@ -259,6 +259,11 @@ public class AddIncomeCommandTest {
         }
 
         @Override
+        public boolean isInView(Transaction transaction) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void keepTrackCommands(Undoable command) {
             throw new AssertionError("This method should not be called.");
         }
@@ -318,6 +323,11 @@ public class AddIncomeCommandTest {
         public void addIncome(Income income) {
             requireNonNull(income);
             transactionsAdded.add(income);
+        }
+
+        @Override
+        public boolean isInView(Transaction transaction) {
+            return transactionsAdded.contains(transaction);
         }
 
         @Override


### PR DESCRIPTION
Other changes:
1. Refactored `LogicManager#execute` to introduce abstraction as there were multiple checks done to the `Command` variable which made the method long and breaks SLAP principle.

*Ignore the following tag(s):*
Resolves #149 